### PR TITLE
Changing build

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -10,7 +10,7 @@ module.exports = {
   apps: [
     {
       name: process.env.DEPLOY_NAME,
-      script: 'dist/server.js',
+      script: './server.js',
       env: {
         COMMON_VARIABLE: 'true',
       },
@@ -34,6 +34,7 @@ module.exports = {
       'post-deploy': [
         'npm install',
         'npm run unit',
+        'npm run build',
         `pm2 reload ecosystem.config.js --env production --name ${process.env.DEPLOY_NAME}`,
       ].join(' && '),
     },


### PR DESCRIPTION
When run `npm run deploy` command, it's breaking. Because the file doesn't exist.

So I added the `npm run build` on `post-deploy` hook and change the dir of server.js file.