### PR TITLE
Fix month format at Toolbar

### DIFF
--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -3,7 +3,10 @@
     <md-button id="btn-previus-month" @click="toPreviousMonth">
       <md-icon>chevron_left</md-icon> {{previous_month_str}}
     </md-button>
-    <h3 class="md-title" style="flex: 1; text-align: center; text-transform: uppercase;">{{state_month_str}}</h3>
+    <h3 class="md-title"
+        style="flex: 1; text-align: center; text-transform: uppercase;">
+        {{state_month_str}}
+    </h3>
     <md-button id="btn-next-month" @click="toNextMonth">
       <md-icon>chevron_right</md-icon> {{next_month_str}}
     </md-button>

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -3,7 +3,7 @@
     <md-button id="btn-previus-month" @click="toPreviousMonth">
       <md-icon>chevron_left</md-icon> {{previous_month_str}}
     </md-button>
-    <h3 class="md-title" style="flex: 1; text-align: center;">{{state_month_str}}</h3>
+    <h3 class="md-title" style="flex: 1; text-align: center; text-transform: uppercase;">{{state_month_str}}</h3>
     <md-button id="btn-next-month" @click="toNextMonth">
       <md-icon>chevron_right</md-icon> {{next_month_str}}
     </md-button>

--- a/src/store/state.js
+++ b/src/store/state.js
@@ -4,8 +4,8 @@ export default {
   user: null,
   current_month: Moment(),
   state_month: Moment(),
-  state_month_str: Moment().format('MMMM YY'),
-  next_month_str: Moment().add(1, 'month').format('MMMM YY'),
-  previous_month_str: Moment().subtract(1, 'month').format('MMMM YY'),
+  state_month_str: Moment().format('MMM YY'),
+  next_month_str: Moment().add(1, 'month').format('MMM YY'),
+  previous_month_str: Moment().subtract(1, 'month').format('MMM YY'),
   flash_message: '',
 };

--- a/src/utils/state.js
+++ b/src/utils/state.js
@@ -1,9 +1,9 @@
 import Moment from 'moment';
 
 export const updateStatesMont = (state) => {
-  state.state_month_str = state.state_month.format('MMMM YY');
-  state.next_month_str = Moment(state.state_month).add(1, 'month').format('MMMM YY');
-  state.previous_month_str = Moment(state.state_month).subtract(1, 'month').format('MMMM YY');
+  state.state_month_str = state.state_month.format('MMM YY');
+  state.next_month_str = Moment(state.state_month).add(1, 'month').format('MMM YY');
+  state.previous_month_str = Moment(state.state_month).subtract(1, 'month').format('MMM YY');
 };
 
 export default updateStatesMont;

--- a/test/e2e/specs/Toolbar.test.js
+++ b/test/e2e/specs/Toolbar.test.js
@@ -11,11 +11,11 @@ describe('Toolbar', () => {
 
     cy.get('#btn-previus-month').click();
 
-    cy.contains('.md-toolbar .md-title', 'junho 18');
+    cy.contains('.md-toolbar .md-title', 'jun 18');
 
     cy.get('#btn-next-month').click();
     cy.get('#btn-next-month').click();
 
-    cy.contains('.md-toolbar .md-title', 'agosto 18');
+    cy.contains('.md-toolbar .md-title', 'ago 18');
   });
 });

--- a/test/unit/specs/Toolbar.spec.js
+++ b/test/unit/specs/Toolbar.spec.js
@@ -20,9 +20,9 @@ describe('Toolbar Component', () => {
       state: {
         current_month: Moment(),
         state_month: Moment(),
-        state_month_str: Moment().format('MMMM YY'),
-        next_month_str: Moment().add(1, 'month').format('MMMM YY'),
-        previous_month_str: Moment().subtract(1, 'month').format('MMMM YY'),
+        state_month_str: Moment().format('MMM YY'),
+        next_month_str: Moment().add(1, 'month').format('MMM YY'),
+        previous_month_str: Moment().subtract(1, 'month').format('MMM YY'),
       },
       getters,
     });

--- a/test/unit/specs/TransactionList.spec.js
+++ b/test/unit/specs/TransactionList.spec.js
@@ -92,9 +92,9 @@ describe('TransactionList Component', () => {
       state: {
         current_month: Moment(),
         state_month: Moment(),
-        state_month_str: Moment().format('MMMM YY'),
-        next_month_str: Moment().add(1, 'month').format('MMMM YY'),
-        previous_month_str: Moment().subtract(1, 'month').format('MMMM YY'),
+        state_month_str: Moment().format('MMM YY'),
+        next_month_str: Moment().add(1, 'month').format('MMM YY'),
+        previous_month_str: Moment().subtract(1, 'month').format('MMM YY'),
       },
       getters,
     });

--- a/test/unit/specs/__snapshots__/Toolbar.spec.js.snap
+++ b/test/unit/specs/__snapshots__/Toolbar.spec.js.snap
@@ -10,15 +10,15 @@ exports[`Toolbar Component Render default 1`] = `
     <mdicon-stub>
       chevron_left
     </mdicon-stub>
-     June 18
+     Jun 18
   
   </mdbutton-stub>
    
   <h3
     class="md-title"
-    style="text-align: center;"
+    style="text-align: center; text-transform: uppercase;"
   >
-    July 18
+    Jul 18
   </h3>
    
   <mdbutton-stub
@@ -27,7 +27,7 @@ exports[`Toolbar Component Render default 1`] = `
     <mdicon-stub>
       chevron_right
     </mdicon-stub>
-     August 18
+     Aug 18
   
   </mdbutton-stub>
 </mdtoolbar-stub>

--- a/test/unit/specs/__snapshots__/Toolbar.spec.js.snap
+++ b/test/unit/specs/__snapshots__/Toolbar.spec.js.snap
@@ -18,7 +18,9 @@ exports[`Toolbar Component Render default 1`] = `
     class="md-title"
     style="text-align: center; text-transform: uppercase;"
   >
-    Jul 18
+    
+      Jul 18
+  
   </h3>
    
   <mdbutton-stub

--- a/test/unit/specs/__snapshots__/TransactionList.spec.js.snap
+++ b/test/unit/specs/__snapshots__/TransactionList.spec.js.snap
@@ -121,7 +121,7 @@ exports[`TransactionList Component Render with transactions 1`] = `
           >
             chevron_left
           </i>
-           June 18
+           Jun 18
   
         </div>
          
@@ -130,9 +130,9 @@ exports[`TransactionList Component Render with transactions 1`] = `
      
     <h3
       class="md-title"
-      style="text-align: center;"
+      style="text-align: center; text-transform: uppercase;"
     >
-      July 18
+      Jul 18
     </h3>
      
     <button
@@ -151,7 +151,7 @@ exports[`TransactionList Component Render with transactions 1`] = `
           >
             chevron_right
           </i>
-           August 18
+           Aug 18
   
         </div>
          

--- a/test/unit/specs/__snapshots__/TransactionList.spec.js.snap
+++ b/test/unit/specs/__snapshots__/TransactionList.spec.js.snap
@@ -132,7 +132,9 @@ exports[`TransactionList Component Render with transactions 1`] = `
       class="md-title"
       style="text-align: center; text-transform: uppercase;"
     >
+      
       Jul 18
+  
     </h3>
      
     <button

--- a/test/unit/specs/store/store.test.js
+++ b/test/unit/specs/store/store.test.js
@@ -27,9 +27,9 @@ describe('store', () => {
       user: null,
       current_month: Moment(),
       state_month: Moment(),
-      state_month_str: Moment().format('MMMM YY'),
-      next_month_str: Moment().add(1, 'month').format('MMMM YY'),
-      previous_month_str: Moment().subtract(1, 'month').format('MMMM YY'),
+      state_month_str: Moment().format('MMM YY'),
+      next_month_str: Moment().add(1, 'month').format('MMM YY'),
+      previous_month_str: Moment().subtract(1, 'month').format('MMM YY'),
     };
   });
 
@@ -89,37 +89,37 @@ describe('store', () => {
       TO_CURRENT_MONTH(state);
 
       expect(state.state_month.toISOString()).toEqual('2018-07-24T23:06:18.215Z');
-      expect(state.state_month_str).toEqual('julho 18');
-      expect(state.next_month_str).toEqual('agosto 18');
-      expect(state.previous_month_str).toEqual('junho 18');
+      expect(state.state_month_str).toEqual('jul 18');
+      expect(state.next_month_str).toEqual('ago 18');
+      expect(state.previous_month_str).toEqual('jun 18');
     });
 
     it('TO_PREVIUS_MONTH', () => {
       expect(state.state_month.toISOString()).toEqual('2018-07-24T23:06:18.215Z');
-      expect(state.state_month_str).toEqual('julho 18');
-      expect(state.next_month_str).toEqual('agosto 18');
-      expect(state.previous_month_str).toEqual('junho 18');
+      expect(state.state_month_str).toEqual('jul 18');
+      expect(state.next_month_str).toEqual('ago 18');
+      expect(state.previous_month_str).toEqual('jun 18');
 
       TO_PREVIUS_MONTH(state);
 
       expect(state.state_month.toISOString()).toEqual('2018-06-24T23:06:18.215Z');
-      expect(state.state_month_str).toEqual('junho 18');
-      expect(state.next_month_str).toEqual('julho 18');
-      expect(state.previous_month_str).toEqual('maio 18');
+      expect(state.state_month_str).toEqual('jun 18');
+      expect(state.next_month_str).toEqual('jul 18');
+      expect(state.previous_month_str).toEqual('mai 18');
     });
 
     it('TO_NEXT_MONTH', () => {
       expect(state.state_month.toISOString()).toEqual('2018-07-24T23:06:18.215Z');
-      expect(state.state_month_str).toEqual('julho 18');
-      expect(state.next_month_str).toEqual('agosto 18');
-      expect(state.previous_month_str).toEqual('junho 18');
+      expect(state.state_month_str).toEqual('jul 18');
+      expect(state.next_month_str).toEqual('ago 18');
+      expect(state.previous_month_str).toEqual('jun 18');
 
       TO_NEXT_MONTH(state);
 
       expect(state.state_month.toISOString()).toEqual('2018-08-24T23:06:18.215Z');
-      expect(state.state_month_str).toEqual('agosto 18');
-      expect(state.next_month_str).toEqual('setembro 18');
-      expect(state.previous_month_str).toEqual('julho 18');
+      expect(state.state_month_str).toEqual('ago 18');
+      expect(state.next_month_str).toEqual('set 18');
+      expect(state.previous_month_str).toEqual('jul 18');
     });
   });
 });


### PR DESCRIPTION
This closes #48 

I've change the string format of `state_month_str`, `next_month_str` and `previous_month_str` from 'MMMM YY' to 'MMM YY', to show only the first three letters of the months and the year. Eg: `AGO 18`